### PR TITLE
Add integration test for minimal transcript extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "bv"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +317,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,7 +367,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -422,6 +456,12 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -545,6 +585,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +666,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,7 +698,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -701,6 +753,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -812,6 +877,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thaf"
 version = "0.0.2"
 dependencies = [
@@ -819,6 +897,7 @@ dependencies = [
  "bio",
  "clap",
  "log",
+ "tempfile",
 ]
 
 [[package]]
@@ -899,6 +978,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wide"
@@ -982,6 +1070,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 bio = "2.3"
 log = "0.4.27"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod transcript_builder;
+pub mod structures;
+pub mod gff3;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,5 @@
-mod transcript_builder;
-mod structures;
-mod gff3;
-
-use crate::gff3::{parse_gff3_to_regions, write_genemap};
-use crate::transcript_builder::{build_transcriptome_sequences, build_transcripts_from_regions};
+use thaf::gff3::{parse_gff3_to_regions, write_genemap};
+use thaf::transcript_builder::{build_transcriptome_sequences, build_transcripts_from_regions};
 use anyhow::Result;
 use clap::{Arg, Command};
 

--- a/tests/minitest.rs
+++ b/tests/minitest.rs
@@ -1,0 +1,62 @@
+use std::fs::File;
+use std::io::Write;
+use tempfile::tempdir;
+use thaf::gff3::parse_gff3_to_regions;
+use thaf::transcript_builder::{build_transcriptome_sequences, build_transcripts_from_regions};
+use bio::io::fasta;
+
+#[test]
+fn minimal_transcript_extraction() -> anyhow::Result<()> {
+    // Create temporary directory for test files
+    let dir = tempdir()?;
+    let gff3_path = dir.path().join("test.gff3");
+    let genome_path = dir.path().join("genome.fa");
+    let transcriptome_path = dir.path().join("trans.fa");
+
+    // Prepare minimal GFF3 with five exon features on two chromosomes
+    {
+        let mut gff = File::create(&gff3_path)?;
+        writeln!(gff, "##gff-version 3")?;
+        writeln!(gff, "chr1\tsrc\tgene\t1\t20\t.\t+\t.\tID=g1")?;
+        writeln!(gff, "chr1\tsrc\tmRNA\t1\t20\t.\t+\t.\tID=tx1;Parent=g1")?;
+        writeln!(gff, "chr1\tsrc\texon\t1\t3\t.\t+\t.\tID=ex1;Parent=tx1")?;
+        writeln!(gff, "chr1\tsrc\texon\t5\t8\t.\t+\t.\tID=ex2;Parent=tx1")?;
+        writeln!(gff, "chr1\tsrc\tgene\t9\t20\t.\t-\t.\tID=g2")?;
+        writeln!(gff, "chr1\tsrc\tmRNA\t9\t20\t.\t-\t.\tID=tx2;Parent=g2")?;
+        writeln!(gff, "chr1\tsrc\texon\t14\t16\t.\t-\t.\tID=ex3;Parent=tx2")?;
+        writeln!(gff, "chr1\tsrc\texon\t18\t20\t.\t-\t.\tID=ex4;Parent=tx2")?;
+        writeln!(gff, "chr2\tsrc\tgene\t1\t10\t.\t+\t.\tID=g3")?;
+        writeln!(gff, "chr2\tsrc\tmRNA\t1\t10\t.\t+\t.\tID=tx3;Parent=g3")?;
+        writeln!(gff, "chr2\tsrc\texon\t2\t4\t.\t+\t.\tID=ex5;Parent=tx3")?;
+    }
+
+    // Minimal genome with two chromosomes
+    {
+        let mut genome = File::create(&genome_path)?;
+        writeln!(genome, ">chr1")?;
+        writeln!(genome, "AAACCCGGGTTTAAACCCGG")?;
+        writeln!(genome, ">chr2")?;
+        writeln!(genome, "GGTTAACCAA")?;
+    }
+
+    // Parse regions and build transcripts
+    let regions = parse_gff3_to_regions(gff3_path.to_str().unwrap(), &vec!["exon".into()])?;
+    let transcripts = build_transcripts_from_regions(regions)?;
+
+    // Build transcript sequences
+    build_transcriptome_sequences(&transcripts, genome_path.to_str().unwrap(), transcriptome_path.to_str().unwrap())?;
+
+    // Read produced FASTA and collect sequences
+    let reader = fasta::Reader::from_file(transcriptome_path)?;
+    let mut seqs = std::collections::HashMap::new();
+    for rec in reader.records() {
+        let rec = rec?;
+        seqs.insert(rec.id().to_owned(), String::from_utf8(rec.seq().to_vec())?);
+    }
+
+    assert_eq!(seqs.get("tx1").unwrap(), "AAACCGG");
+    assert_eq!(seqs.get("tx2").unwrap(), "CCGGTT");
+    assert_eq!(seqs.get("tx3").unwrap(), "GTT");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `tempfile` dev-dependency
- expose internal modules via `lib.rs`
- update `main.rs` to use the new library
- add integration test `minitest.rs` creating minimal GFF3 and FASTA files

## Testing
- `cargo test`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_686e83513ec0832c96f25c23291c245e